### PR TITLE
One bug fix and 4 minor features

### DIFF
--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -473,6 +473,13 @@ snippet dm "Math" wA
 \]
 endsnippet
 
+# add comma and period \]. -> .\] and \], -> ,\]
+# replace comma and period ,\]. -> .\]
+# support space between \]  , -> ,\]
+snippet "([,\.]*)\\]\s*([,\.])" "Add ',' '.' for display math" rA
+`!p snip.rv=match.group(2)`\\] 
+endsnippet
+
 context "math()"
 snippet ali "Align" bA
 \begin{aligned}


### PR DESCRIPTION
## Bugfix
1. fix a bug for snippet `bmat` and `pmat`

## Feature
1. Remove snippet `'` ->`^\prime`. `'` is a shortcut for `^\prime` in LaTeX. One advantage of `'` is that ` A''^{-1}_1 `will be displayed as double prime, all other superscripts and subscripts behave as if `'` is not used. (It works fine and will not show "double superscript" error if `breqn` package is not used). It seems that `\prime` is necessary only when subscript. See [this discussion in tex sX](https://tex.stackexchange.com/questions/87134/what-is-the-advantage-of-using-f-prime-instead-of-f).
2. Fast switching for 1. \ldots \cdots \ddots 2. font sizes 3 spacing
3. Add Extensible arrows `\xleftarrow` to the sequence `LeftArrows`. (See section 5.1 in [amsmath doc](https://texdoc.org/serve/amsmath/0).) 
4. Automatically add and replace `,` and `.` for display math `\[ ... \]`
- add comma and period `\].` -> `.\]` and `\],` -> `,\] `. It is OK if there is spaces before `.` and `,`
- replace comma and period `,\].` -> `.\] `, `.\],` -> `,\] `, `.\].` -> `.\] `, `,\],` -> `,\] `
- support space between `\]  ,` -> `,\] `