### PR TITLE
Add a solution for bmat pmat and several minor fixes

### DIFF
--- a/UltiSnips/mathtex.snippets
+++ b/UltiSnips/mathtex.snippets
@@ -398,7 +398,7 @@ ${1:`!p
 selectedcode = [x for x in snip.v.text.split("\n") if x]
 for (i, x) in enumerate(selectedcode):
 		index = findfirstoperator(x)
-		snip.rv += ("" if i == 0 else "		 ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
+		snip.rv += ("" if i == 0 else "    ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
 `}
 \end{aligned}
 endsnippet
@@ -411,7 +411,7 @@ ${1:`!p
 selectedcode = [x for x in snip.v.text.split("\n") if x]
 for (i, x) in enumerate(selectedcode):
 		index = findfirstoperator(x)
-		snip.rv += ("" if i == 0 else "		 ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
+		snip.rv += ("" if i == 0 else "    ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
 `}\end{aligned}
 \]
 endsnippet
@@ -549,8 +549,20 @@ snippet floor "floor" iA
 endsnippet
 
 context "math()"
-snippet pmat "pmat" w
-\begin{pmatrix} $1 \end{pmatrix} $0
+snippet pmat "pmat" wm
+\begin{pmatrix}${1:`!p
+# add &
+regex = r"(?<=\w)[ \t]+(?=\w)"
+subst = r"\t&\t"
+snip.rv = re.sub(regex, subst, snip.v.text, 0, re.MULTILINE)
+# add \t\\\n
+snip.rv = ("\t\\\\\n"+snip.mkline()).join([x.strip() for x in snip.rv.split("\n") if x])
+# one line or multiple lines
+if snip.v.text.count('\n') > 1:
+	snip.rv = '\n' + snip.mkline() + snip.rv + '\n' + snip.mkline()
+else:
+	snip.rv = " " + snip.rv + " "
+`}\end{pmatrix} $0
 endsnippet
 
 post_jump "generate_matrix('p', snip)"
@@ -562,9 +574,35 @@ if not snip.c:
 `
 endsnippet
 
+# seperate each element with spaces or \t select them and trigger
+# the snippets bellow, it will be properly wrapped in a matrix environment.
+# Example:
+# select the folling two line in visual mode
+# 1 0 9 2 8
+# 9 8 733 0 7
+# bmat<tab>
+# it will turn to
+# \begin{bmatrix}
+# 1	&	0	&	9	&	2	&	8	\\
+# 9	&	8	&	733	&	0	&	7
+# \end{bmatrix}
+# Hint: This snippet will not check the dimension of the matrix
+# You cannot use this with block selection mode i.e. CTRL-V
 context "math()"
-snippet bmat "bmat" w
-\begin{bmatrix} $1 \end{bmatrix} $0
+snippet bmat "bmat" wm
+\begin{bmatrix}${1:`!p
+# add &
+regex = r"(?<=\w)[ \t]+(?=\w)"
+subst = r"\t&\t"
+snip.rv = re.sub(regex, subst, snip.v.text, 0, re.MULTILINE)
+# add \t\\\n
+snip.rv = ("\t\\\\\n"+snip.mkline()).join([x.strip() for x in snip.rv.split("\n") if x])
+# one line or multiple lines
+if snip.v.text.count('\n') > 1:
+	snip.rv = '\n' + snip.mkline() + snip.rv + '\n' + snip.mkline()
+else:
+	snip.rv = " " + snip.rv + " "
+`}\end{bmatrix} $0
 endsnippet
 
 post_jump "generate_matrix('b', snip)"
@@ -1110,6 +1148,12 @@ priority 100
 context "math()"
 snippet "(\\?[a-zA-Z]\w*)bar" "bar" riA
 \overline{`!p snip.rv=match.group(1)`}
+endsnippet
+
+priority 100
+context "math()"
+snippet "(\\?[a-zA-Z]\w*)dot" "dot" riA
+\dot{`!p snip.rv=match.group(1)`}
 endsnippet
 
 priority 100

--- a/UltiSnips/mathtex.snippets
+++ b/UltiSnips/mathtex.snippets
@@ -195,29 +195,29 @@ def extract_operator(line):
 		return rv
 
 def findfirstoperator(line):
-    index = 0
-    depth = 0
-    while index < len(line):
-        if line[index] == '\s':
-            index += 1
-            continue
-        elif line[index] in ['{', '(']:
-            depth += 1
-            index += 1
-            continue
-        elif line[index] in ['}', ')']:
-            depth -= 1
-            index += 1
-            continue
-        elif depth <= 0 and line[index] == '=':
-            return index
-        elif depth <= 0 and all(line[index:].startswith(x) for x in ["\\le", "\\ge", ">", "<", "\\succ", "\\prec", "\\sim", "\\ne", "\\not"]):
-            return index
-        else:
-            index += 1
-            continue
-    else:
-        return len(line) - len(line.lstrip())
+		index = 0
+		depth = 0
+		while index < len(line):
+				if line[index] == '\s':
+						index += 1
+						continue
+				elif line[index] in ['{', '(']:
+						depth += 1
+						index += 1
+						continue
+				elif line[index] in ['}', ')']:
+						depth -= 1
+						index += 1
+						continue
+				elif depth <= 0 and line[index] == '=':
+						return index
+				elif depth <= 0 and all(line[index:].startswith(x) for x in ["\\le", "\\ge", ">", "<", "\\succ", "\\prec", "\\sim", "\\ne", "\\not"]):
+						return index
+				else:
+						index += 1
+						continue
+		else:
+				return len(line) - len(line.lstrip())
 
 def findmatched_parentheses(line, lindex):
 	depth = 0
@@ -397,8 +397,8 @@ snippet ali "Align" bA
 ${1:`!p
 selectedcode = [x for x in snip.v.text.split("\n") if x]
 for (i, x) in enumerate(selectedcode):
-    index = findfirstoperator(x)
-    snip.rv += ("" if i == 0 else "    ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
+		index = findfirstoperator(x)
+		snip.rv += ("" if i == 0 else "		 ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
 `}
 \end{aligned}
 endsnippet
@@ -410,8 +410,8 @@ snippet bali "Align with {" bA
 ${1:`!p
 selectedcode = [x for x in snip.v.text.split("\n") if x]
 for (i, x) in enumerate(selectedcode):
-    index = findfirstoperator(x)
-    snip.rv += ("" if i == 0 else "    ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
+		index = findfirstoperator(x)
+		snip.rv += ("" if i == 0 else "		 ") + x[:index] + "&" + x[index:] + "\\\\" + ("" if i == len(selectedcode) - 1 else "\n")
 `}\end{aligned}
 \]
 endsnippet
@@ -429,14 +429,14 @@ endsnippet
 #  \end{aligned}
 #  \] .
 #  , \\  
-#    .   \end{aligned}
-#   . \] .
-#  ,   
-#    .   \end{aligned}
-#   . \] .
+#		 .	 \end{aligned}
+#		. \] .
+#  ,	 
+#		 .	 \end{aligned}
+#		. \] .
 #  
-#  ,  .   \end{aligned}
-#   . \],
+#  ,	.		\end{aligned}
+#		. \],
 # snippet "([,.]?)\s*(\\\\)?(\n?)\s*[,.]?\s*(\\end{aligned})(\n?)\s*[,.]?\s*(\\])\s*([,.])" "align comma" irmA
 # `!p snip.rv = match.group(3) +match.group(7) +match.group(4) +match.group(5) +match.group(6)`
 # endsnippet
@@ -720,7 +720,7 @@ if snip.context['works'] == 0:
 		# print("line [672] vim.eval(\"getline('.')\"): ###%s###" % vim.eval("getline('.')"))
 		# print("line [673] content: ###%s###" % content)
 		# print("line [674] vim.eval(\"col('.')\"): ###%s###" % vim.eval("col('.')"))
-		candidate = sum([[t[0] for t in re.findall("(?<=" + name  + r"_\{)(([^\{\}]+|\{[^\{\}]+\})+)(?=\})", x)][::-1] for x in content], [])
+		candidate = sum([[t[0] for t in re.findall("(?<=" + name + r"_\{)(([^\{\}]+|\{[^\{\}]+\})+)(?=\})", x)][::-1] for x in content], [])
 		candidate = list(dict.fromkeys(candidate))
 		candidate = [x[len(t[1]):] for x in candidate if x.startswith(t[1]) and len(t[1]) < len(x)]
 		# print("line [679] candidate: ###%s###" % candidate)
@@ -1330,7 +1330,7 @@ endsnippet
 ######################
 # Usage:
 # Let n<space> -> "Let $n$ "
-# For each i,<space>  -> For each $i$,<space>
+# For each i,<space>	-> For each $i$,<space>
 # 'a', 'A' and 'I' are excluded in this snippet
 # This regex will match string like " s ", " s, " and " s) "
 # It is very useful when there is many single-letter symbols in sentences.
@@ -1354,15 +1354,15 @@ snip.rv='$'+match.group(1)+'$'+match.group(2)`
 endsnippet
 
 
-# word .   -> word. 
+# word .	 -> word. 
 # word.  , -> word,
-# $i$ )    -> $i$) 
+# $i$ )		 -> $i$) 
 context "not math()"
 snippet "(?<=[\w\$])[,.]?\s+([,.\)])" "remove ' ' before ',' '.' ')'" iwrA
 `!p snip.rv=match.group(1)` 
 endsnippet
 
-# ( word .   -> ( word. 
+# ( word .	 -> ( word. 
 context "not math()"
 snippet "(?<=\()\s+(\w+)" "remove space after '('" iwrA
 `!p snip.rv=match.group(1)`
@@ -1375,4 +1375,4 @@ snippet "(?<=\.)\s*([a-ce-ln-zA-Z])" "Auto upper cases after ." iwrA
 endsnippet
 
 
-# vim ft=snippet
+# vim: ts=2 sw=2 noet:list:ft=snippets:

--- a/UltiSnips/tex.snippets
+++ b/UltiSnips/tex.snippets
@@ -74,30 +74,6 @@ def extract_operator(line):
 					continue
 		return rv
 
-def findfirstoperator(line):
-    index = 0
-    depth = 0
-    while index < len(line):
-        if line[index] == '\s':
-            index += 1
-            continue
-        elif line[index] in ['{', '(']:
-            depth += 1
-            index += 1
-            continue
-        elif line[index] in ['}', ')']:
-            depth -= 1
-            index += 1
-            continue
-        elif depth <= 0 and line[index] == '=':
-            return index
-        elif depth <= 0 and all(line[index:].startswith(x) for x in ["\\le", "\\ge", ">", "<", "\\succ", "\\prec", "\\sim", "\\ne", "\\not"]):
-            return index
-        else:
-            index += 1
-            continue
-    else:
-        return len(line) - len(line.lstrip())
 
 def findmatched_parentheses(line, lindex):
 	depth = 0
@@ -122,13 +98,6 @@ def findmatched_parentheses(line, lindex):
 				return index
 	return -1
 
-def vim_left_all(max_line = 100, offset = 0):
-	left = vim.eval("getline('.')[:col('.')-2+(%d)]" % offset)
-	content = [left]
-	currentlinenumber = int(vim.eval("line('.')"))
-	for index in range(currentlinenumber-1, max(0, currentlinenumber - max_line) if max_line > 0 else -1, -1):
-		content.append(vim.eval('getline(%d)' % index))
-	return content
 
 def add_placeholder(snip):
 	info = snip.buffer[snip.line]
@@ -593,5 +562,4 @@ snippet "(?<=\S)\s{2,}" "remove double spaces" iwrA
  
 endsnippet
 
-
-# vim ft=snippet
+# vim: ts=2 sw=2 noet:list:ft=snippets:


### PR DESCRIPTION
1. bmat pmat: all you need is to separate each element with space or tab.
Select in visual mode
```
1 0 9 2 \mu
9 8 3 0 7
```
press `bmat<tab>`
it will turn to
```
\begin{bmatrix}
1	&	0	&	9	&	2	&	\mu	\\
9	&	8	&	3	&	0	&	7
\end{bmatrix}
```

Now, anything that is separated by a space will be seen as different elements. This may lead to some inconvenience, for
example, inserting `\mu a`. Here is some direction to solve this problem:
> 1. only use tab but not space to separate elements, but this is not perfect because some vim users will use softtab.
> 2. Use tab and 2+ spaces to separate elements. Anything separated by only one space will be seen as one element.
> 3. surround the content with space in it with `(...)` to indicate that it is an element.

Do you have any other ideas?

2. Fix modeline `vim` -> `vim:`, `snippet` -> `snippets`.
3. Consistent tab: use tab now.